### PR TITLE
Updating installation instructions to pip based ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
      - conda info -a
      - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION
      - source activate test-env
-     - conda install -c conda-forge opencv=4.5.3
      - pip install .
     script:
      - pytest -s

--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ git checkout main
 ```
 Install OpenCV using conda and the rest of packages using `pip`.
 ```
-conda install -c conda-forge opencv=4.5.3
 pip install .
 ```
+
+**Note**: For some OS (e.g. Mojave OSX), the OpenCV installation can take too long, if this is the case you can also install
+the library from conda using the line `conda install -c conda-forge opencv=4.5.3`. Also, be careful about versions,
+older openCV versions can break this code. 
 
 ## Running `PyLithics`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 scikit-image
 scipy
 pyyaml
+opencv-contrib-python


### PR DESCRIPTION
Fixes #130 

We were using a mix of conda and pip installation instructions for OpenCV, we now move to only pip installation. 